### PR TITLE
Add getter for external android dependencies

### DIFF
--- a/GodotAndroidVkAds/export_scripts/export_plugin.gd
+++ b/GodotAndroidVkAds/export_scripts/export_plugin.gd
@@ -27,5 +27,13 @@ class AndroidExportPlugin extends EditorExportPlugin:
 		else:
 			return PackedStringArray([_plugin_name + "/bin/release/" + _plugin_name + "-release.aar"])
 
+	
+	func _get_android_dependencies(platform, debug):
+		if debug:
+			return PackedStringArray(["com.my.target:mytarget-sdk:5.21.0"])
+		else:
+			return PackedStringArray(["com.my.target:mytarget-sdk:5.21.0"])
+
+
 	func _get_name():
 		return _plugin_name


### PR DESCRIPTION
Добавил функцию геттер для внешних зависимостей в код плагина.
Теперь,  опять же, пользователям не нужно будет включать их через  build.gradle

Вот эти строки более не нужны в новых сборках:
```
dependencies {
    ...
    implementation "com.my.target:mytarget-sdk:5.21.0"
}
```

